### PR TITLE
 Stop terminating long builds on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ install:
   esac
 
 script:
+- travis_wait 30 sleep 1800 &
 - |
   case "$BUILD" in
     stack)


### PR DESCRIPTION
By default travis will terminate a build after 10 minutes with no build
output. Travis provides a utilty, travis_wait, to help with this issue.
However there is a [know
issue](https://github.com/travis-ci/travis-ci/issues/7020) that this
utility will strip quotes from the command being run.

By running this utility on a sleep command and running in the
background, the build will complete as normal and not be terminated.