### PR TITLE
Typo in css: changed "=" to ":"

### DIFF
--- a/src/Skylighting/Format/HTML.hs
+++ b/src/Skylighting/Format/HTML.hs
@@ -173,7 +173,7 @@ styleToCss f = unlines $ divspec ++ numberspec ++ colorspec ++ linkspec ++ map t
           , "}"
           ]
          linkspec = [ "@media screen {"
-          , "a.sourceLine::before { text-decoration: underline; color = initial; }"
+          , "a.sourceLine::before { text-decoration: underline; color: initial; }"
           , "}"
           ]
 


### PR DESCRIPTION
Discovered this while runing a minifier: the css syntax was incorrect. I don't master CSS but this looks like a fix ;)

PS : I just *love* pandoc (thus skylighting quite often!) and use them everywhere. A big thank!