### PR TITLE
Fix line spacing and overflowing content in generated html

### DIFF
--- a/src/Skylighting/Format/HTML.hs
+++ b/src/Skylighting/Format/HTML.hs
@@ -186,7 +186,7 @@ styleToCss f = unlines $
           , "}"
           ]
          linkspec = [ "@media screen {"
-          , "a.sourceLine::before { text-decoration: underline; color: initial; }"
+          , "a.sourceLine::before { text-decoration: underline; }"
           , "}"
           ]
 

--- a/src/Skylighting/Format/HTML.hs
+++ b/src/Skylighting/Format/HTML.hs
@@ -143,7 +143,7 @@ styleToCss f = unlines $
   divspec ++ numberspec ++ colorspec ++ linkspec ++
     sort (map toCss (Map.toList (tokenStyles f)))
    where colorspec = [
-           "div.sourceCode, pre.sourceCode, code.sourceCode\n  { "
+           "div.sourceCode\n  { "
            ++ case (defaultColor f, backgroundColor f) of
                 (Nothing, Nothing) -> ""
                 (Just c, Nothing)  -> "color: " ++ fromColor c ++ ";"

--- a/src/Skylighting/Format/HTML.hs
+++ b/src/Skylighting/Format/HTML.hs
@@ -154,6 +154,8 @@ styleToCss f = unlines $
          numberspec = [
             "pre.numberSource a.sourceLine"
           , "  { position: relative; }"
+          , "pre.numberSource a.sourceLine:empty"
+          , "  { position: absolute; }"
           , "pre.numberSource a.sourceLine::before"
           , "  { content: attr(data-line-number);"
           , "    position: absolute; left: -5em; text-align: right; vertical-align: baseline;"
@@ -174,9 +176,9 @@ styleToCss f = unlines $
          divspec = [
             "a.sourceLine { display: inline-block; line-height: 1.25; }"
           , "a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }"
-          , "a.sourceLine:empty { height: 1em; }" -- correct empty line height
+          , "a.sourceLine:empty { height: 1.2em; position: absolute; }" -- correct empty line height
           , ".sourceCode { overflow: visible; }" -- needed for line numbers
-          , "code.sourceCode { white-space: pre; }"
+          , "code.sourceCode { white-space: pre; position: relative; }" -- position relative needed for absolute contents
           , "@media screen {"
           , "div.sourceCode { overflow: auto; }" -- do not overflow on screen
           , "}"

--- a/src/Skylighting/Format/HTML.hs
+++ b/src/Skylighting/Format/HTML.hs
@@ -177,6 +177,9 @@ styleToCss f = unlines $
           , "a.sourceLine:empty { height: 1em; }" -- correct empty line height
           , ".sourceCode { overflow: visible; }" -- needed for line numbers
           , "code.sourceCode { white-space: pre; }"
+          , "@media screen {"
+          , "div.sourceCode { overflow: auto; }" -- do not overflow on screen
+          , "}"
           , "@media print {"
           , "code.sourceCode { white-space: pre-wrap; }"
           , "a.sourceLine { text-indent: -1em; padding-left: 1em; }"

--- a/src/Skylighting/Format/HTML.hs
+++ b/src/Skylighting/Format/HTML.hs
@@ -172,8 +172,9 @@ styleToCss f = unlines $
               " padding-left: 4px; }"
           ]
          divspec = [
-            "a.sourceLine { display: inline-block; min-height: 1.25em; }"
+            "a.sourceLine { display: inline-block; line-height: 1.25; }"
           , "a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }"
+          , "a.sourceLine:empty { height: 1em; }" -- correct empty line height
           , ".sourceCode { overflow: visible; }" -- needed for line numbers
           , "code.sourceCode { white-space: pre; }"
           , "@media print {"


### PR DESCRIPTION
Fixes wrong spacing on empty lines, and code overflowing the outer div on screen.
 
See jgm/pandoc#4128

Note: not yet tested with pandoc - that will have to wait a few hours. But tested cross-browser.

The option without the wrapping `div` involves messing with `code` display, and plays poorly with things such as border-radius. This approach makes fewer changes.