### PR TITLE
Generate css using clay

### DIFF
--- a/skylighting.cabal
+++ b/skylighting.cabal
@@ -232,6 +232,7 @@ library
                        text,
                        binary,
                        bytestring,
+                       clay >= 0.12.2,
                        directory,
                        filepath,
                        aeson,

--- a/src/Skylighting/Format/HTML.hs
+++ b/src/Skylighting/Format/HTML.hs
@@ -16,6 +16,7 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 import Clay (Css)
 import qualified Clay as C
+import qualified Clay.Render as C
 import qualified Clay.Media as CM
 import qualified Clay.Text as CT
 
@@ -144,7 +145,11 @@ short NormalTok         = ""
 
 -- | Returns CSS for styling highlighted code according to the given style.
 styleToCss :: Style -> String
-styleToCss = TL.unpack . C.renderWith C.compact [] . styleToCss'
+styleToCss = TL.unpack . C.renderWith config [] . styleToCss'
+  where
+    config = C.compact
+      { C.rbrace = fromString "}\n"
+      }
 
 styleToCss' :: Style -> Css
 styleToCss' f = do

--- a/src/Skylighting/Format/HTML.hs
+++ b/src/Skylighting/Format/HTML.hs
@@ -144,7 +144,7 @@ short NormalTok         = ""
 
 -- | Returns CSS for styling highlighted code according to the given style.
 styleToCss :: Style -> String
-styleToCss = TL.unpack . C.render . styleToCss'
+styleToCss = TL.unpack . C.renderWith C.compact [] . styleToCss'
 
 styleToCss' :: Style -> Css
 styleToCss' f = do

--- a/src/Skylighting/Types.hs
+++ b/src/Skylighting/Types.hs
@@ -55,6 +55,7 @@ import Data.Word
 import Safe (readMay)
 import Skylighting.Regex
 import Text.Printf
+import qualified Clay as C
 
 -- | Full name of a context: the first member of the pair is the full
 -- syntax name, the second the context name within that syntax.
@@ -334,6 +335,9 @@ instance FromColor (Double, Double, Double) where
 
 instance FromColor (Word8, Word8, Word8) where
   fromColor (RGB r g b) = (r, g, b)
+
+instance FromColor C.Color where
+  fromColor (RGB r g b) = C.rgb (toInteger r) (toInteger g) (toInteger b)
 
 -- | A rendering style. This determines how each kind of token
 -- is to be rendered, and sets a default color and background


### PR DESCRIPTION
<https://hackage.haskell.org/package/clay> is a DSL for CSS. This PR would replace the text based CSS generation with that DSL. It matches the output for the current skylighting HEAD (see <https://dbaynard.github.io/test-html/tests/skylighting.html> for example).

There are two outstanding issues, but I'm making the PR now as I'll then actually finish it.

1.  `clay` modules need to be imported qualified as they do not mesh well with `blaze`. This commit presents that option; it is more than a little noisy, though. I'm inclined to generate the CSS in a new module and import that. Actually, I've noticed that you prefer parentheses to the `$` style so I'll change that where relevant, too.
2.  `clay` currently does not output comments, so the `clay` output doesn't quite match the hand-rolled output  (but see sebastiaanvisser/clay#149).

I'd also like to document what the CSS bits do, as it will ease future maintenance.

If there are no issues with the new module (and the pretty printing looks OK) I'll go ahead and work on the `clay` issue above, and when that's all fixed hopefully this can be merged.