### PR TITLE
Display line numbers without absolute positioning

### DIFF
--- a/skylighting-core/src/Skylighting/Format/HTML.hs
+++ b/skylighting-core/src/Skylighting/Format/HTML.hs
@@ -153,13 +153,11 @@ styleToCss f = unlines $
            ++ " }"]
          numberspec = [
             "pre.numberSource a.sourceLine"
-          , "  { position: relative; }"
-          , "pre.numberSource a.sourceLine:empty"
-          , "  { position: absolute; }"
+          , "  { position: relative; left: -4em; }"
           , "pre.numberSource a.sourceLine::before"
           , "  { content: attr(data-line-number);"
-          , "    position: absolute; left: -5em; text-align: right; vertical-align: baseline;"
-          , "    border: none; pointer-events: all;"
+          , "    position: relative; left: -1em; text-align: right; vertical-align: baseline;"
+          , "    border: none; pointer-events: all; display: inline-block;"
           , "    -webkit-touch-callout: none; -webkit-user-select: none;"
           , "    -khtml-user-select: none; -moz-user-select: none;"
           , "    -ms-user-select: none; user-select: none;"
@@ -176,9 +174,9 @@ styleToCss f = unlines $
          divspec = [
             "a.sourceLine { display: inline-block; line-height: 1.25; }"
           , "a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }"
-          , "a.sourceLine:empty { height: 1.2em; position: absolute; }" -- correct empty line height
+          , "a.sourceLine:empty { height: 1.2em; }" -- correct empty line height
           , ".sourceCode { overflow: visible; }" -- needed for line numbers
-          , "code.sourceCode { white-space: pre; position: relative; }" -- position relative needed for absolute contents
+          , "code.sourceCode { white-space: pre; position: relative; }" -- position relative needed for relative contents
           , "div.sourceCode { margin: 1em 0; }" -- Collapse neighbours correctly
           , "pre.sourceCode { margin: 0; }" -- Collapse neighbours correctly
           , "@media screen {"


### PR DESCRIPTION
Fixes #32 

Test with numbering visible at <https://dbaynard.github.io/test-html/tests/skylighting.html>. Epubs validate with epubcheck.