### PR TITLE
Fix build on GHC 7.8.4

### DIFF
--- a/skylighting-core/skylighting-core.cabal
+++ b/skylighting-core/skylighting-core.cabal
@@ -111,7 +111,7 @@ library
                        Skylighting.Format.LaTeX
   other-extensions:    CPP, Arrows
   build-depends:       base >= 4.7 && < 5.0,
-                       mtl,
+                       mtl >= 2.2.1,
                        transformers,
                        text,
                        binary,

--- a/skylighting-core/src/Skylighting/Format/HTML.hs
+++ b/skylighting-core/src/Skylighting/Format/HTML.hs
@@ -6,7 +6,7 @@ module Skylighting.Format.HTML (
 
 import Data.List (intersperse, sort)
 import qualified Data.Map as Map
-import Data.Monoid ((<>))
+import Data.Monoid ((<>), mconcat)
 import Data.String (fromString)
 import qualified Data.Text as Text
 import Skylighting.Types

--- a/skylighting-core/src/Skylighting/Loader.hs
+++ b/skylighting-core/src/Skylighting/Loader.hs
@@ -5,10 +5,11 @@ module Skylighting.Loader ( loadSyntaxFromFile
                           )
                           where
 
+import Control.Applicative ((<$>))
 import Control.Monad (filterM, foldM)
 import Control.Monad.Except (ExceptT(ExceptT), runExceptT)
 import Control.Monad.IO.Class (liftIO)
-import Data.Monoid ((<>))
+import Data.Monoid ((<>), mempty)
 import System.Directory (listDirectory, doesFileExist)
 import System.FilePath ((</>), takeExtension)
 

--- a/skylighting-core/src/Skylighting/Regex.hs
+++ b/skylighting-core/src/Skylighting/Regex.hs
@@ -12,6 +12,7 @@ module Skylighting.Regex (
               , convertOctalEscapes
               ) where
 
+import Control.Applicative (Applicative ((<*>)), (<$>))
 import qualified Control.Exception as E
 import Data.Aeson
 import Data.Binary (Binary)

--- a/skylighting-core/src/Skylighting/Types.hs
+++ b/skylighting-core/src/Skylighting/Types.hs
@@ -52,6 +52,7 @@ import Data.Int
 import Data.List (minimumBy)
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
+import Data.Monoid (Monoid (mempty))
 import Data.Ord (comparing)
 import qualified Data.Set as Set
 import Data.Text (Text)

--- a/skylighting-core/test/test-skylighting.hs
+++ b/skylighting-core/test/test-skylighting.hs
@@ -3,12 +3,14 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main where
+
+import Control.Applicative ((<$>))
 import qualified Control.Exception as E
 import Data.Aeson (decode, encode)
 import Data.Algorithm.Diff
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
-import Data.Monoid ((<>))
+import Data.Monoid ((<>), mconcat)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text


### PR DESCRIPTION
Currently this package falsely advertises compatibility with base 4.7. This PR makes it compatible with that base version (shipped with GHC 7.8)

An alternative to this is to change the base lower bound to `base >= 4.8` to make it explicit that GHC 7.8 is no longer supported.
As a Hackage trustee, I've revised existing versions of skylighting-core to give them that bound, preventing bad install plans on GHC 7.8