### PR TITLE
Export WordSet constructors

### DIFF
--- a/skylighting-core/src/Skylighting/Types.hs
+++ b/skylighting-core/src/Skylighting/Types.hs
@@ -11,7 +11,7 @@ module Skylighting.Types (
               -- * Syntax descriptions
                 ContextName
               , KeywordAttr(..)
-              , WordSet
+              , WordSet(..)
               , makeWordSet
               , inWordSet
               , Matcher(..)


### PR DESCRIPTION
There is presently, as far as I can tell, no way to access the list of words contained in a `WordSet`; so I'd like to have the constructors exported so I can pull a word set apart.

The use case is that I'm trying to write a function to modify the Haskell `Syntax` to add some keywords introduced by GHC extensions (`forall`, `via`), so I'd like to be able to write a `WordSet -> WordSet` function that adds keywords to a set.