### PR TITLE
Handle starting numbers (fix regression in #72)

### DIFF
--- a/skylighting-core/src/Skylighting/Format/HTML.hs
+++ b/skylighting-core/src/Skylighting/Format/HTML.hs
@@ -74,7 +74,11 @@ formatHtmlBlock opts ls =
 wrapCode :: FormatOptions -> Html -> Html
 wrapCode opts h = H.code ! A.class_ (toValue $ Text.unwords
                                              $ Text.pack "sourceCode"
-                                               : codeClasses opts) $ h
+                                               : codeClasses opts)
+                         !? (startZero /= 0, A.style (toValue counterOverride))
+                         $ h
+  where  counterOverride = "counter-reset: source-line " <> show startZero <> ";"
+         startZero = startNumber opts - 1
 
 -- | Each line of source is wrapped in an (inline-block) anchor that makes
 -- subsequent per-line processing (e.g. adding line numnbers) possible.


### PR DESCRIPTION
Two commits. One implements the change from https://github.com/jgm/pandoc/issues/4386#issuecomment-496502656 that I forgot to implement (thanks @mb21). The other adds a new option, `-N`, to skylighting, which controls this — I found it helpful to test, but it might also be useful for standalone use of skylighting. By all means, bikeshed the names, etc.

I've tested with skylighting, only (not with pandoc). I'd happily do more here, but given the test suite only tests the parser, I'm not sure what is best.