### PR TITLE
Prevent invalid CSS generation

### DIFF
--- a/skylighting-core/src/Skylighting/Format/HTML.hs
+++ b/skylighting-core/src/Skylighting/Format/HTML.hs
@@ -190,7 +190,7 @@ styleToCss f = unlines $
           ]
 
 toCss :: (TokenType, TokenStyle) -> String
-toCss (t,tf) = "code span." ++ short t ++ " { "
+toCss (t,tf) = "code span" ++ (if short t == "" then "" else "." ++ short t) ++ " { "
                 ++ colorspec ++ backgroundspec ++ weightspec ++ stylespec
                 ++ decorationspec ++ "} /* " ++ showTokenType t ++ " */"
   where colorspec = maybe "" (\col -> "color: " ++ fromColor col ++ "; ") $ tokenColor tf

--- a/skylighting-core/src/Skylighting/Format/HTML.hs
+++ b/skylighting-core/src/Skylighting/Format/HTML.hs
@@ -190,7 +190,7 @@ styleToCss f = unlines $
           ]
 
 toCss :: (TokenType, TokenStyle) -> String
-toCss (t,tf) = "code span" ++ (if short t == "" then "" else "." ++ short t) ++ " { "
+toCss (t,tf) = "code span" ++ (if null (short t) then "" else ('.' : short t)) ++ " { "
                 ++ colorspec ++ backgroundspec ++ weightspec ++ stylespec
                 ++ decorationspec ++ "} /* " ++ showTokenType t ++ " */"
   where colorspec = maybe "" (\col -> "color: " ++ fromColor col ++ "; ") $ tokenColor tf


### PR DESCRIPTION
`code span. {` is invalid CSS. It works in all browsers, however, it yields a warning when used in epub-validator.

Therefore I suggest this fix. I never wrote any Haskell before thus sorry for my non-idiomatic style. I'll gladly update the PR with any suggestions the maintainers make. Thank you :)