### PR TITLE
Add TOML.

### DIFF
--- a/skylighting-core/xml/toml.xml
+++ b/skylighting-core/xml/toml.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language SYSTEM "language.dtd"
+[
+	<!ENTITY more "(_\d+)*">
+	<!ENTITY int  "[+-]?(0|[1-9]\d*)&more;">
+	<!ENTITY frac "\.\d+&more;">
+	<!ENTITY exp  "[eE][+-]?\d+&more;">
+
+	<!ENTITY offset   "[+-]\d\d:\d\d">
+	<!ENTITY time     "\d\d:\d\d:\d\d(\.\d+)?(&offset;|Z)?">
+	<!ENTITY datetime "\d\d\d\d-\d\d-\d\d(T&time;)?">
+]>
+<!-- https://github.com/toml-lang/toml -->
+<language name="TOML" section="Configuration" extensions="*.toml" mimetype="text/x-toml" version="5" kateversion="5.0" author="flying-sheep@web.de" license="LGPLv2+">
+<highlighting>
+	<list name="bools">
+		<item>true</item>
+		<item>false</item>
+	</list>
+	<contexts>
+		<context attribute="Error" lineEndContext="#stay" name="Toml">
+			<DetectSpaces attribute="Whitespace"/>
+			<Detect2Chars attribute="TableHeader" context="NestedTableHeader" char="[" char1="[" endRegion="Table"/>
+			<DetectChar attribute="TableHeader" context="TableHeader" char="[" endRegion="Table"/>
+			<RegExpr    attribute="Key" context="#stay"   String="[\w-]+" firstNonSpace="true"/>
+			<DetectChar attribute="Key" context="QuotedKey" char="&quot;" firstNonSpace="true"/>
+			<DetectChar attribute="Assignment" context="Value" char="="/>
+			<DetectChar char="#" attribute="Comment" context="Comment"/>
+		</context>
+		<!-- table headers -->
+		<context attribute="TableHeader" fallthrough="true" fallthroughContext="#pop" lineEndContext="#pop" name="TableHeader">
+			<IncludeRules context="TableHeaderCommon"/>
+			<DetectChar attribute="TableHeader" context="#pop" char="]" beginRegion="Table"/>
+		</context>
+		<context attribute="TableHeader" fallthrough="true" fallthroughContext="#pop" lineEndContext="#pop" name="NestedTableHeader">
+			<IncludeRules context="TableHeaderCommon"/>
+			<Detect2Chars attribute="TableHeader" context="#pop" char="]" char1="]" beginRegion="Table"/>
+		</context>
+		<context attribute="TableHeader" lineEndContext="#pop" name="TableHeaderCommon">
+			<DetectSpaces attribute="Whitespace"/>
+			<DetectChar attribute="TableHeader" context="#stay" char="."/>
+			<RegExpr    attribute="Key" context="#stay" String="[\w-]+"/>
+			<DetectChar attribute="Key" context="QuotedKey" char="&quot;"/>
+		</context>
+		<!-- values -->
+		<context attribute="Normal Text" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop" name="Value">
+			<DetectSpaces attribute="Whitespace"/>
+			<RegExpr attribute="Date"  context="#stay" String="&datetime;"/>
+			<keyword attribute="Bool" String="bools" context="#stay"/>
+			<RegExpr attribute="Float" context="#stay" String="&int;(&frac;&exp;|&frac;|&exp;)"/>
+			<RegExpr attribute="Int"   context="#stay" String="&int;"/>
+			<StringDetect attribute="String" context="MultilineString"    String="&quot;&quot;&quot;"/>
+			<DetectChar   attribute="String" context="String"               char="&quot;"/>
+			<StringDetect attribute="String" context="LitMultilineString" String="'''"/>
+			<DetectChar   attribute="String" context="LitString"            char="'"/>
+			<DetectChar attribute="Array" context="Array" char="["/>
+			<DetectChar attribute="InlineTable" context="InlineTable" char="{"/>
+			<DetectChar char="#" attribute="Comment" context="Comment"/>
+		</context>
+		<context attribute="Comment" lineEndContext="#pop" name="Comment">
+			<DetectSpaces/>
+			<IncludeRules context="##Alerts" />
+			<DetectIdentifier/>
+		</context>
+		<!-- Quoted keys and Strings -->
+		<context attribute="Key" lineEndContext="#pop" name="QuotedKey">
+			<LineContinue attribute="Escape" context="#stay"/>
+			<RegExpr attribute="Escape" String="\\[btnfr&quot;\\]" context="#stay" />
+			<RegExpr attribute="Escape" String="\\(u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})" context="#stay" />
+			<RegExpr attribute="Error" String="\\." context="#stay" />
+			<DetectChar attribute="Key" context="#pop" char="&quot;"/>
+		</context>
+		<context attribute="String" lineEndContext="#pop" name="String">
+			<LineContinue attribute="Escape" context="#stay"/>
+			<RegExpr attribute="Escape" String="\\[btnfr&quot;\\]" context="#stay" />
+			<RegExpr attribute="Escape" String="\\(u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})" context="#stay" />
+			<RegExpr attribute="Error" String="\\." context="#stay" />
+			<DetectChar attribute="String" context="#pop" char="&quot;"/>
+		</context>
+		<context attribute="String" lineEndContext="#stay" name="MultilineString">
+			<LineContinue attribute="Escape" context="#stay"/>
+			<RegExpr attribute="Escape" String="\\[btnfr&quot;\\]" context="#stay" />
+			<RegExpr attribute="Escape" String="\\(u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})" context="#stay" />
+			<RegExpr attribute="Error" String="\\." context="#stay" />
+			<StringDetect attribute="String" context="#pop" String="&quot;&quot;&quot;"/>
+		</context>
+		<context attribute="LitString" lineEndContext="#pop" name="LitString">
+			<DetectChar attribute="String" context="#pop" char="'"/>
+		</context>
+		<context attribute="LitString" lineEndContext="#stay" name="LitMultilineString">
+			<StringDetect attribute="String" context="#pop" String="'''"/>
+		</context>
+		<!-- Arrays -->
+		<context attribute="Array" lineEndContext="#stay" name="Array">
+			<IncludeRules context="Value" />
+			<DetectChar context="#pop" attribute="Array" char="]" />
+			<DetectChar context="#stay" attribute="NextEntry" char="," />
+		</context>
+		<context attribute="InlineTable" lineEndContext="#stay" name="InlineTable">
+			<RegExpr    attribute="Key" context="#stay"   String="[\w-]+"/>
+			<DetectChar attribute="Key" context="QuotedKey" char="&quot;"/>
+			<DetectChar attribute="Assignment" context="Value" char="="/>
+			<DetectChar char="#" attribute="Comment" context="Comment"/>
+			<DetectChar context="#pop" attribute="InlineTable" char="}" />
+			<DetectChar context="#stay" attribute="NextEntry" char="," />
+		</context>
+	</contexts>
+	<itemDatas>
+		<itemData name="Normal Text" defStyleNum="dsNormal"/>
+		<itemData name="Key"         defStyleNum="dsDataType"/>
+		<itemData name="TableHeader" defStyleNum="dsKeyword"/>
+		<itemData name="Assignment"  defStyleNum="dsOperator"/>
+		<itemData name="Comment"     defStyleNum="dsComment"/>
+
+		<itemData name="Date"        defStyleNum="dsBaseN"/>
+		<itemData name="Float"       defStyleNum="dsFloat"/>
+		<itemData name="Int"         defStyleNum="dsDecVal"/>
+		<itemData name="Bool"        defStyleNum="dsConstant"/>
+		<itemData name="String"      defStyleNum="dsString"/>
+		<itemData name="LitString"   defStyleNum="dsVerbatimString"/>
+		<itemData name="Escape"      defStyleNum="dsSpecialChar"/>
+		<itemData name="Array"       defStyleNum="dsOperator"/>
+		<itemData name="InlineTable" defStyleNum="dsOperator"/>
+		<itemData name="NextEntry"   defStyleNum="dsOperator"/>
+
+		<itemData name="Whitespace"  defStyleNum="dsNormal"/>
+		<itemData name="Error"       defStyleNum="dsError"/>
+	</itemDatas>
+</highlighting>
+<general>
+	<comments>
+		<comment name="singleLine" start="#" />
+	</comments>
+</general>
+</language>

--- a/skylighting/skylighting.cabal
+++ b/skylighting/skylighting.cabal
@@ -173,6 +173,7 @@ library
                        Skylighting.Syntax.Tcl
                        Skylighting.Syntax.Tcsh
                        Skylighting.Syntax.Texinfo
+                       Skylighting.Syntax.Toml
                        Skylighting.Syntax.Typescript
                        Skylighting.Syntax.Verilog
                        Skylighting.Syntax.Vhdl


### PR DESCRIPTION
Imported from
https://github.com/KDE/syntax-highlighting/blob/2d8eab6f502e7d817b1840ad12463f4562be3999/data/syntax/toml.xml (with trailing whitespaces stripped).

TOML is pretty widely used these days, for instance in the Python ecosystem ([`pyproject.toml`](https://www.python.org/dev/peps/pep-0621/)) and the Rust ecosystem (`Cargo.toml`). It would be nice to support it in Pandoc out of the box.