### PR TITLE
Hide invisible line numbers from keyboard focus

### DIFF
--- a/skylighting-core/src/Skylighting/Format/HTML.hs
+++ b/skylighting-core/src/Skylighting/Format/HTML.hs
@@ -95,6 +95,10 @@ sourceLineToHtml opts lno cont =
                      then mempty
                      else customAttribute (fromString "aria-hidden")
                            (fromString "true")) -- see jgm/pandoc#6352
+               ! (if numberLines opts
+                     then mempty
+                     else customAttribute (fromString "tabindex")
+                           (fromString "-1"))
                $ mempty
            mapM_ (tokenToHtml opts) cont
   where  lineNum = toValue prefixedLineNo


### PR DESCRIPTION
This fixes tabbing through elements on a page.
For example, before this change, when line numbers are hidden, you would
need to press tab once for each line to get to the next visible link.

See also:
https://act-rules.github.io/rules/6cfa84#failed-example-1