### PR TITLE
Updated cabal instructions in the Readme.me

### DIFF
--- a/skylighting/README.md
+++ b/skylighting/README.md
@@ -70,10 +70,10 @@ package.
 Using cabal:
 
     cd skylighting-core
-    cabal install -fexecutable
+    cabal v1-install -fexecutable
     cd ../skylighting
     skylighting-extract ../skylighting-core/xml/*.xml
-    cabal install -fexecutable
+    cabal v1-install -fexecutable
 
 Using stack:
 


### PR DESCRIPTION
Hullo! I'm trying to expand the syntax support to add a new language, and I noticed that the readme points to `cabal install`, which I think no longer works as expects, defaulting to `v2-install`, I believe the command needed would be `v1-install` (at least that's what worked for me).