### PR TITLE
Notch up core test timeout even further

### DIFF
--- a/skylighting-core/test/test-skylighting.hs
+++ b/skylighting-core/test/test-skylighting.hs
@@ -224,7 +224,7 @@ p_no_drop cfg syntax t =
 
 noDropTest :: TokenizerConfig -> [Text] -> Syntax -> TestTree
 noDropTest cfg inps syntax =
-  localOption (mkTimeout 25000000)
+  localOption (mkTimeout 75000000)
   $ testCase (Text.unpack (sName syntax))
   $ mapM_ go inps
     where go inp =
@@ -238,7 +238,7 @@ noDropTest cfg inps syntax =
                       assertFailure ("Unexpected error: " ++ e ++ "\ninput = " ++ show inp)
 
 tokenizerTest :: TokenizerConfig -> SyntaxMap -> Bool -> FilePath -> TestTree
-tokenizerTest cfg sMap regen inpFile = localOption (mkTimeout 25000000) $
+tokenizerTest cfg sMap regen inpFile = localOption (mkTimeout 75000000) $
   goldenTest testname getExpected getActual
       (compareValues referenceFile) updateGolden
   where testname = lang ++ " tokenizing of " ++ inpFile


### PR DESCRIPTION
On very slow/embedded cpus, 25 seconds is not sufficient (even 50 seconds is not); I had to notch the test timeout up to 75 seconds for everything to pass.