### PR TITLE
Some performance improvements

### DIFF
--- a/skylighting-core/src/Skylighting/Tokenizer.hs
+++ b/skylighting-core/src/Skylighting/Tokenizer.hs
@@ -121,7 +121,7 @@ instance MonadPlus TokenizerM where
 
 instance MonadReader TokenizerConfig TokenizerM where
   ask = TM (\c s -> (s, Success c))
-  local f (TM x) = TM (\c s -> x (f c) s)
+  local f (TM x) = TM (x . f)
 
 instance MonadState TokenizerState TokenizerM where
   get = TM (\_ s -> (s, Success s))

--- a/skylighting-core/src/Skylighting/Tokenizer.hs
+++ b/skylighting-core/src/Skylighting/Tokenizer.hs
@@ -68,9 +68,9 @@ data Result e a = Success a
 
 deriving instance (Show a, Show e) => Show (Result e a)
 
-data TokenizerM a = TM { runTokenizerM :: TokenizerConfig
-                                       -> TokenizerState
-                                       -> (TokenizerState, Result String a) }
+newtype TokenizerM a = TM { runTokenizerM :: TokenizerConfig
+                                          -> TokenizerState
+                                          -> (TokenizerState, Result String a) }
 
 mapsnd :: (a -> b) -> (c, a) -> (c, b)
 mapsnd f (x, y) = (x, f y)


### PR DESCRIPTION
Replacing `data` with `newtype` shaves off some numbers from the benchmark. Before (showing only `mean`), the lowest means out of three runs (the numbers for the first benchmark about parsing omitted, as they aren't changed):
```
mean                 14.89 ms   (14.86 ms .. 14.94 ms)
mean                 6.550 ms   (6.493 ms .. 6.700 ms)
mean                 3.246 ms   (3.204 ms .. 3.332 ms)
mean                 16.88 ms   (16.85 ms .. 16.93 ms)
mean                 16.42 ms   (16.30 ms .. 16.74 ms)
mean                 15.28 ms   (15.26 ms .. 15.30 ms)
```

After the change, the best out of three:
```
mean                 14.09 ms   (14.03 ms .. 14.24 ms)
mean                 6.204 ms   (6.148 ms .. 6.344 ms)
mean                 3.059 ms   (3.067 ms .. 3.202 ms)
mean                 15.97 ms   (16.13 ms .. 16.28 ms)
mean                 14.98 ms   (14.88 ms .. 15.40 ms)
mean                 14.61 ms   (14.62 ms .. 14.73 ms)
```

So, it's roughly 5-10% improvement.

Curiously, the other change, replacing the lambda with a `.`, also improves the run time and memory consumption of my own project (which uses hakyll, which uses pandoc, which uses skylighting). Overall, my own project runs faster by about 7% and consumes about 7% less peak RAM.