### PR TITLE
ConTeXt: fix escaping of special chars.

### DIFF
--- a/skylighting-format-context/src/Skylighting/Format/ConTeXt.hs
+++ b/skylighting-format-context/src/Skylighting/Format/ConTeXt.hs
@@ -46,16 +46,16 @@ escapeConTeXt :: Text -> Text
 escapeConTeXt = Text.concatMap escapeConTeXtChar
   where escapeConTeXtChar c =
          case c of
-           '\\' -> "\\letterbackslash "
-           '{'  -> "\\letteropenbrace "
-           '}'  -> "\\letterclosebrace "
-           '|'  -> "\\letterbar "
-           '$'  -> "\\letterdollar "
-           '_'  -> "\\letterunderscore "
-           '%'  -> "\\letterpercent "
-           '#'  -> "\\letterhash "
-           '/'  -> "\\letterslash "
-           '~'  -> "\\lettertilde "
+           '\\' -> "\\letterbackslash{}"
+           '{'  -> "\\letteropenbrace{}"
+           '}'  -> "\\letterclosebrace{}"
+           '|'  -> "\\letterbar{}"
+           '$'  -> "\\letterdollar{}"
+           '_'  -> "\\letterunderscore{}"
+           '%'  -> "\\letterpercent{}"
+           '#'  -> "\\letterhash{}"
+           '/'  -> "\\letterslash{}"
+           '~'  -> "\\lettertilde{}"
            _    -> Text.singleton c
 
 -- ConTeXt


### PR DESCRIPTION
The character commands gobbled spaces after the special chars. In contrast to LaTeX macros, ConTeXt commands appear to consume all spaces after the command. Using an empty span `{}` as delimiter command works better.