### PR TITLE
ConTeXt: fix handling of spaces in non-normal tokens

### DIFF
--- a/skylighting-format-context/src/Skylighting/Format/ConTeXt.hs
+++ b/skylighting-format-context/src/Skylighting/Format/ConTeXt.hs
@@ -40,7 +40,12 @@ tokenToConTeXt :: Token -> Text
 tokenToConTeXt (NormalTok, txt)
   | Text.all isSpace txt = escapeConTeXt txt
 tokenToConTeXt (toktype, txt)   = "/BTEX\\" <>
-  (Text.pack (show toktype) <> "{" <> escapeConTeXt txt <> "}/ETEX")
+  (Text.pack (show toktype) <> "{" <> fixSpaces (escapeConTeXt txt) <> "}/ETEX")
+ where
+  -- Always place the second of two consecutive spaces in a group. The
+  -- ConTeXt parser would otherwise collapse all spaces into a single
+  -- space.
+  fixSpaces = Text.replace "  " " { }"
 
 escapeConTeXt :: Text -> Text
 escapeConTeXt = Text.concatMap escapeConTeXtChar


### PR DESCRIPTION
This ensures that multiple spaces won't be collapsed into a single
space.
