### PR TITLE
Store compiled regexes in RE

### DIFF
--- a/skylighting-core/src/Skylighting/Regex.hs
+++ b/skylighting-core/src/Skylighting/Regex.hs
@@ -2,11 +2,14 @@
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Skylighting.Regex (
                 Regex(..)
-              , RE(..)
+              , RE
+              , pattern RE, reCaseSensitive, reString
+              , compileRE
               , compileRegex
               , matchRegex
               , testRegex
@@ -14,25 +17,81 @@ module Skylighting.Regex (
               ) where
 
 import Data.Aeson
-import Data.Binary (Binary)
+import Data.Binary (Binary(..))
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Char8 as BS
 import Data.Data
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TE
-import GHC.Generics (Generic)
 #if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail (MonadFail)
 #endif
 import Regex.KDE
 
--- | A representation of a regular expression.
-data RE = RE{
-    reString        :: BS.ByteString
-  , reCaseSensitive :: Bool
-} deriving (Show, Read, Ord, Eq, Data, Typeable, Generic)
+import Text.Read hiding (get)
 
-instance Binary RE
+-- | A representation of a regular expression.
+data RE = RE'{
+    _reString        :: BS.ByteString
+  , _reCaseSensitive :: Bool
+  , reCompiled'      :: Either String Regex
+} deriving Typeable
+
+-- We define a smart constructor which also holds the compiled regex, to avoid
+-- recompiling each time we tokenize.
+
+{-# COMPLETE RE #-}
+pattern RE :: BS.ByteString -> Bool  -> RE
+pattern RE {reString, reCaseSensitive} <- RE' reString reCaseSensitive _ where
+  RE str caseSensitive = RE' str caseSensitive (compileRegex caseSensitive str)
+
+-- Unfortunately this means we need to derive all the instances ourselves.
+
+instance Show RE where
+  showsPrec d (RE str caseSensitive) = showParen (d > 10) 
+    $ showString "RE {reString = " 
+    . showsPrec 11 str
+    . showString ", reCaseSensitive = "
+    . showsPrec 11 caseSensitive
+    . showString "}"
+
+instance Read RE where
+  readPrec = parens . prec 10 $ do
+    Ident "RE" <- lexP
+    Punc "{" <- lexP
+    Ident "reString" <- lexP
+    Punc "=" <- lexP
+    str <- readPrec
+    Punc "," <- lexP
+    Ident "reCaseSensitive" <- lexP
+    Punc "=" <- lexP
+    caseSensitive <- readPrec
+    Punc "}" <- lexP
+    pure (RE str caseSensitive)
+
+toComparisonKey :: RE -> (BS.ByteString, Bool)
+toComparisonKey (RE x y) = (x, y)
+
+instance Eq RE where
+  x == y = toComparisonKey x == toComparisonKey y
+
+instance Ord RE where
+  x `compare` y = toComparisonKey x `compare` toComparisonKey y
+
+conRE :: Constr
+conRE = mkConstr tyRE "RE" [] Prefix
+tyRE :: DataType
+tyRE   = mkDataType "Skylighting.Regex.RE" [conRE]
+
+instance Data RE where
+  gfoldl k z (RE s c) = z RE `k` s `k` c
+  gunfold k z _ = k (k (z RE))
+  toConstr _ = conRE
+  dataTypeOf _ = tyRE
+
+instance Binary RE where
+  put (RE x y) = put x >> put y
+  get = RE <$> get <*> get
 
 instance ToJSON RE where
   toJSON re = object [ "reString"        .= encodeToText (reString re)
@@ -49,3 +108,6 @@ encodeToText = TE.decodeUtf8 . Base64.encode
 
 decodeFromText :: (Monad m, MonadFail m) => Text.Text -> m BS.ByteString
 decodeFromText = either fail return . Base64.decode . TE.encodeUtf8
+
+compileRE :: RE -> Either String Regex
+compileRE = reCompiled'

--- a/skylighting-core/src/Skylighting/Regex.hs
+++ b/skylighting-core/src/Skylighting/Regex.hs
@@ -34,7 +34,7 @@ import Text.Read hiding (get)
 data RE = RE'{
     _reString        :: BS.ByteString
   , _reCaseSensitive :: Bool
-  , reCompiled'      :: Either String Regex
+  , _reCompiled      :: Either String Regex
 } deriving Typeable
 
 -- We define a smart constructor which also holds the compiled regex, to avoid
@@ -110,4 +110,4 @@ decodeFromText :: (Monad m, MonadFail m) => Text.Text -> m BS.ByteString
 decodeFromText = either fail return . Base64.decode . TE.encodeUtf8
 
 compileRE :: RE -> Either String Regex
-compileRE = reCompiled'
+compileRE = _reCompiled


### PR DESCRIPTION
I'm currently working on a project which contains a large number (4k+) of Agda code blocks in markdown files. When debugging some performance issues we were having with our build process, I noticed that we were spending a large amount of time in Pandoc's HTML writer.

Using GHC's profiler, we can see that most of the time is spent in compiling and parsing Skylighting's regex.

![A screenshot of a Speedscope profile. The majority of the time is spent in an `option` function (from Attoparsec), which is called from `compileRegex` and `tokenize` (from Skyulighting) and in turn from Pandoc's `writeHTML5String`. The whole process takes 22s](https://github.com/jgm/skylighting/assets/4346137/eb88518d-7b89-464f-9950-495d32be0615)

In order to avoid repeated re-compiles of regexes for each call to `tokenize`, this patch (lazily) compiles the regex when constructing a `RE` value. This ensures the compiled regex is shared across all usages of the syntax.

This has a significant affect on performance, reducing the total build time from ~38s to ~24s. Another profile for comparison (though I'm a little dubious of the relative speedup in profiling builds):

![Another screenshot of a Speedscope profile. Tokenize now takes up much less time (~1.5s), and the whole process only takes 6.5s.](https://github.com/jgm/skylighting/assets/4346137/71ebc76f-5202-4151-9d07-76531d692a1d)

There is some awkwardness here, as we now need to derive all the type classes manually. This is especially irritating for the `Show`/`Read` instances. I'm not sure there's a good alternative here.

I've tried to hide the hide the internals of this - we're using pattern synonyms to keeping the interface the same as before (`RE { reString, reCaseSensitive }`).

