### PR TITLE
Derive `Bounded` Instance for `TokenType`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Revision history for skylighting and skylighting-core
 
+## master
+
+  * Add `Bounded` instance for `TokenType`.
+
 ## 0.13.3
 
   * Add gap language (#167).
@@ -953,4 +957,3 @@
 ## 0.1.0.0  -- 2016-12-23
 
   * Initial release
-

--- a/skylighting-core/src/Skylighting/Types.hs
+++ b/skylighting-core/src/Skylighting/Types.hs
@@ -221,7 +221,7 @@ data TokenType = KeywordTok
                | AlertTok
                | ErrorTok
                | NormalTok
-               deriving (Read, Show, Eq, Ord, Enum, Data, Typeable, Generic)
+               deriving (Read, Show, Eq, Ord, Enum, Bounded, Data, Typeable, Generic)
 
 instance Binary TokenType
 


### PR DESCRIPTION
In one of my projects I wanted to convert my molokai vim colorscheme into a skylighting `Style`. 

To build the `tokenStyles` field, I wanted to map over a list of all TokenTypes & pass them through to a function that uses `case ... of`:

```haskell
    tokenStyles :: M.Map TokenType TokenStyle
    tokenStyles =
        M.fromList $ [(tok, tokenStyle tok) | tok <- allTokens]
    tokenStyle :: TokenType -> TokenStyle
    tokenStyle = \case
        KeywordTok ->
            bold $ color "#F92672"
        DataTypeTok ->
            color "#66D9EF"
```

I can't define `allTokens` generically, I'm stuck using discrete values for the start & end of the range:
```haskell
    tokenStyles :: M.Map TokenType TokenStyle
    tokenStyles =
        M.fromList $ [(t, tokenStyle t) | SkyToken t <- [minBound .. maxBound]]

-- | Custom type for deriving "Bounded TokenType".
newtype SkyToken = SkyToken TokenType
    deriving newtype (Enum)

instance Bounded SkyToken where
    minBound = SkyToken KeywordTok
    maxBound = SkyToken NormalTok
```

With a derived `Bounded` instance for `TokenType`, I can drop my `SkyToken` newtype & ensure any newly added values to the `TokenType` type get pulled into my list of "all tokens". 

---

Add `Bounded` to the derived instances for the `TokenType` type. This allows consumers to use `[minBound .. maxBound]` to generate a list of all token types when writing a `Style`.