### PR TITLE
Fix jgm/pandoc#9292

### DIFF
--- a/skylighting-format-blaze-html/src/Skylighting/Format/HTML.hs
+++ b/skylighting-format-blaze-html/src/Skylighting/Format/HTML.hs
@@ -205,7 +205,7 @@ styleToCss f = unlines $
           , "}"
           , "@media print {"
           , "pre > code.sourceCode { white-space: pre-wrap; }"
-          , "pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }"
+          , "pre > code.sourceCode > span { display: inline-block; }"
           , "}"
           ]
          linkspec = [ "@media screen {"


### PR DESCRIPTION
This PR aims to fix https://github.com/jgm/pandoc/issues/9292

I'm not sure what the  `(-5 + 5)` calculation was trying to do -- it [was added] in a commit about line numbers (#14), but doesn't seem to affect HTML rendering in firefox:

![image](https://github.com/jgm/skylighting/assets/95857153/64326593-4c0b-408a-a2bc-31822b1362bb)

Weasyprint always renders the code better without:

![image](https://github.com/jgm/skylighting/assets/95857153/3d4512de-7622-498d-965e-49acded0412d)

Test source code:

``````markdown

<style>
body { columns: 2; }
div.sourceCode { border: 2pt solid black; }
.old {border: 1px solid red}
.new {border: 1px solid green}
.new pre > code.sourceCode > span {
  text-indent:  0 !important;
  padding-left: 0 !important;
}
</style>

:::: old

```{.haskell}
-- Here is some haskell code
-- which doesn't quite fit
-- into a 2-column layout
(>=>) :: Monad m => (a -> m b) -> (b -> m c) -> a -> m c
(bs >=> cs) a = do
  b <- bs a
  cs b
```

```{.haskell .numberLines}
-- Here is some haskell code
-- which doesn't quite fit
-- into a 2-column layout
(>=>) :: Monad m => (a -> m b) -> (b -> m c) -> a -> m c
(bs >=> cs) a = do
  b <- bs a
  cs b
```

::::

:::: new

```{.haskell}
-- Here is some haskell code
-- which doesn't quite fit
-- into a 2-column layout
(>=>) :: Monad m => (a -> m b) -> (b -> m c) -> a -> m c
(bs >=> cs) a = do
  b <- bs a
  cs b
```

```{.haskell .numberLines}
-- Here is some haskell code
-- which doesn't quite fit
-- into a 2-column layout
(>=>) :: Monad m => (a -> m b) -> (b -> m c) -> a -> m c
(bs >=> cs) a = do
  b <- bs a
  cs b
```

::::

``````

HTML generated with `pandoc test.md --standalone --pdf-engine weasyprint -o out.html`

PDF generated with `pandoc test.md --standalone --pdf-engine weasyprint -o out.pdf`

[was added]: https://github.com/jgm/skylighting/commit/8a44b8613f5165ffeb917e5ebb28450b8a569d48#diff-fd5b0787fb5eb358b0149fbab54b772771099a796b33e40e8bcb1a2a8f819685R161