### PR TITLE
Use `-webkit-text-size-adjust` instead of unsetting inline-block

### DIFF
--- a/skylighting-format-blaze-html/src/Skylighting/Format/HTML.hs
+++ b/skylighting-format-blaze-html/src/Skylighting/Format/HTML.hs
@@ -205,7 +205,7 @@ styleToCss f = unlines $
           , "}"
           , "@media print {"
           , "pre > code.sourceCode { white-space: pre-wrap; }"
-          , "pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }"
+          , "pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }"
           , "}"
           ]
          linkspec = [ "@media screen {"

--- a/skylighting-format-blaze-html/src/Skylighting/Format/HTML.hs
+++ b/skylighting-format-blaze-html/src/Skylighting/Format/HTML.hs
@@ -194,7 +194,7 @@ styleToCss f = unlines $
           ]
          divspec = [
             "pre > code.sourceCode { white-space: pre; position: relative; }" -- position relative needed for relative contents
-          , "pre > code.sourceCode > span { line-height: 1.25; }"
+          , "pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }"
           , "pre > code.sourceCode > span:empty { height: 1.2em; }" -- correct empty line height
           , ".sourceCode { overflow: visible; }" -- needed for line numbers
           , "code.sourceCode > span { color: inherit; text-decoration: inherit; }"

--- a/skylighting-format-blaze-html/src/Skylighting/Format/HTML.hs
+++ b/skylighting-format-blaze-html/src/Skylighting/Format/HTML.hs
@@ -193,7 +193,8 @@ styleToCss f = unlines $
               " padding-left: 4px; }"
           ]
          divspec = [
-            "pre > code.sourceCode { white-space: pre; position: relative; }" -- position relative needed for relative contents
+            "html { -webkit-text-size-adjust: 100%; }" -- Work around iOS bug, see https://github.com/jgm/pandoc/issues/7248
+          , "pre > code.sourceCode { white-space: pre; position: relative; }" -- position relative needed for relative contents
           , "pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }"
           , "pre > code.sourceCode > span:empty { height: 1.2em; }" -- correct empty line height
           , ".sourceCode { overflow: visible; }" -- needed for line numbers


### PR DESCRIPTION
Having `display: inline-block;` is useful. I frequently customize the
pandoc code block styles to allow for line highlights (see [1]).
The CSS styles for those line hightlights rely on the enclosing `span`
for a line being able to span the full width of the code block, which is
not possible without making the `span` be `display: inline-block;`.

The original issue reported in https://github.com/jgm/pandoc/issues/7248
was that specifically iOS Safari renders font sizes incorrectly.

This is a known iOS bug. I first discovered the workaround for it while
working with the tufte-css project (see [2]), and similar workarounds
are implemented in various CSS normalize/reset projects.

I have verified that including this `-webkit-text-size-adjust` property
fixes the original bug reported against pandoc. Given that the solution
in this PR allows keeping `display: inline-block;` which has its own
uses, fixes the original bug, and is an iOS-specific solution to an
iOS-specific problem, I believe that this is a more compelling long-term
solution (at least until iOS decides to change this behavior).

I, of course, defer to the maintainers of the skylighting project as to
whether you want this change. I've already worked around this problem in
my own projects that consume the output of pandoc- and
skylighting-highlighted code blocks (by basically vendoring these
changes into those projects), so I am not personally blocked. I'm
contributing this change upstream in the hopes that it might help
unblock others.

[1]: https://jez.io/pandoc-markdown-css-theme/features/#numbered-and-highlighted-lines
[2]: https://github.com/edwardtufte/tufte-css/issues/81#issuecomment-261953409

- - - - -

Related prior work:

- [original bug](https://github.com/jgm/pandoc/issues/7248) → [original fix](https://github.com/jgm/skylighting/commit/0ec889227c4a603bc7f9262b7952cb7a660d1829)
- [subsequent print bug](https://github.com/jgm/pandoc/issues/9520) → [subsequent print fix](https://github.com/jgm/skylighting/commit/15682b2aeeac3a0f28601a12f281afe4c7bfbce4)
- [similar problem faced by tufte-css project](https://github.com/edwardtufte/tufte-css/issues/81#issuecomment-261953409)
- [similar problem worked around by jez/pandoc-markdown-css-theme project](https://github.com/jez/pandoc-markdown-css-theme/blob/67c1d1cb8ac81b6cbb4144cc24ae429a195f0fca/public/css/theme.css#L146-L149)