### PR TITLE
Update JSON syntax definition from upstream.

### DIFF
--- a/skylighting-core/xml/json.xml
+++ b/skylighting-core/xml/json.xml
@@ -13,7 +13,7 @@
  ** https://www.json.org/json-en.html
  ***************************************************************************
 -->
-<language name="JSON" section="Markup" version="8" kateversion="2.4" extensions="*.json;.kateproject;.arcconfig;*.geojson;*.gltf;*.theme" mimetype="application/json" author="Sebastian Pipping (sebastian@pipping.org)" license="GPL">
+<language name="JSON" section="Markup" version="9" kateversion="2.4" extensions="*.json;*.jsonl;.kateproject;.arcconfig;*.geojson;*.gltf;*.theme;*.cast" mimetype="application/json" author="Sebastian Pipping (sebastian@pipping.org)" license="GPL">
   <highlighting>
     <list name="Constants">
       <item>null</item>
@@ -62,7 +62,7 @@
 
         <keyword String="Constants" context="#stay" attribute="Style_Keyword" />
 
-        <RegExpr String="-?\b([1-9][0-9]*\.[0-9]+(?:[eE][+-]?[0-9]+)?)" context="#stay" attribute="Style_Float" />
+        <RegExpr String="-?\b((0\b|[1-9][0-9]*)\.[0-9]+(?:[eE][+-]?[0-9]+)?)" context="#stay" attribute="Style_Float" />
         <RegExpr String="-?\b(0\b|[1-9][0-9]*(?:[eE][+-]?[0-9]+)?)" context="#stay" attribute="Style_Decimal" />
       </context>
 


### PR DESCRIPTION
Please update the JSON syntax definition.

The old one rejects numbers with a single `0` before a decimal point. This has been fixed [upstream](https://github.com/KDE/syntax-highlighting/blob/master/data/syntax/json.xml).